### PR TITLE
Update ImagePreview.js

### DIFF
--- a/src/components/BPJsonForm/ImagePreview.js
+++ b/src/components/BPJsonForm/ImagePreview.js
@@ -62,7 +62,7 @@ const ImagePreview = ({ url, label, isInvalidURL }) => {
         unmountOnExit
         classes={{ wrapperInner: classes.center }}
       >
-        <img className={classes.media} src={url} title="branding image" />
+        <img className={classes.media} src={url} alt="node entity logo" />
       </Collapse>
     </List>
   )


### PR DESCRIPTION
Fixes this issue : 

```
8:24:37 AM: Failed to compile.
8:24:37 AM: 
8:24:37 AM: ./src/components/BPJsonForm/ImagePreview.js
8:24:37 AM:   Line 65:9:  img elements must have an alt prop, either with meaningful text, or an empty string for decorative images  jsx-a11y/alt-text
8:24:37 AM: error Command failed with exit code 1.
```